### PR TITLE
Fix refresh rate

### DIFF
--- a/gopher.go
+++ b/gopher.go
@@ -6,7 +6,7 @@ const (
 	gopherWidth  = 24
 	gopherHeight = 24
 
-	g    = 0.25 // Gravity (重力加速度) の略
+	g    = 0.05 // Gravity (重力加速度) の略
 	jump = -1.0 // ジャンプ力
 )
 

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func updateGame() {
 
 	for _, wall := range walls {
 		wall.move()
-		if frames%5 == 0 {
+		if frames%4 == 0 {
 			wall.move()
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -8,12 +8,10 @@ import (
 )
 
 var (
-	frames               = 0             // 経過フレーム数
-	moveInterval         = 5             // 壁の追加間隔
-	newWallsInterval     = 200           // 新しい壁を追加する間隔
-	wallMovementInterval = 10            // 壁の移動量
-	wallStartX           = 240           // 壁の初期X座標
-	walls                = []*wallData{} // 壁のX座標とY座標
+	frames           = 0             // 経過フレーム数
+	newWallsInterval = 200           // 新しい壁を追加する間隔
+	wallStartX       = 240           // 壁の初期X座標
+	walls            = []*wallData{} // 壁のX座標とY座標
 
 	scene = "title"
 	score = 0
@@ -121,39 +119,38 @@ func updateGame() {
 		}
 	}
 
-	if frames%wallMovementInterval == 0 {
-		for _, wall := range walls {
+	for _, wall := range walls {
+		wall.move()
+		if frames%5 == 0 {
 			wall.move()
 		}
 	}
 
-	if frames%moveInterval == 0 {
-		gopher.move()
+	gopher.move()
 
-		for _, wall := range walls {
-			// 上の壁を表す四角形を作る
-			bLeft, bTop, bRight, bBottom := wall.top()
+	for _, wall := range walls {
+		// 上の壁を表す四角形を作る
+		bLeft, bTop, bRight, bBottom := wall.top()
 
-			// 上の壁との当たり判定
-			if gopher.isHit(bLeft, bTop, bRight, bBottom) {
-				scene = "gameover"
-			}
+		// 上の壁との当たり判定
+		if gopher.isHit(bLeft, bTop, bRight, bBottom) {
+			scene = "gameover"
+		}
 
-			// 下の壁を表す四角形を作る
-			bLeft, bTop, bRight, bBottom = wall.bottom()
+		// 下の壁を表す四角形を作る
+		bLeft, bTop, bRight, bBottom = wall.bottom()
 
-			// 下の壁との当たり判定
-			if gopher.isHit(bLeft, bTop, bRight, bBottom) {
-				scene = "gameover"
-			}
+		// 下の壁との当たり判定
+		if gopher.isHit(bLeft, bTop, bRight, bBottom) {
+			scene = "gameover"
+		}
 
-			_, t, _, b := gopher.position()
-			if t < 0 {
-				scene = "gameover"
-			}
-			if b > 160 {
-				scene = "gameover"
-			}
+		_, t, _, b := gopher.position()
+		if t < 0 {
+			scene = "gameover"
+		}
+		if b > 160 {
+			scene = "gameover"
 		}
 	}
 }

--- a/wall.go
+++ b/wall.go
@@ -15,7 +15,7 @@ type wallData struct {
 }
 
 func (w *wallData) move() {
-	w.wallX -= 8
+	w.wallX -= 1
 }
 
 func (w *wallData) draw() {


### PR DESCRIPTION
Problem: The gopher position is updated every 5 frames and walls position is updated every 10 frames. It creates a visible lag.

Solution: update positions every frame.

Problem: sometimes, the first hole can be to high to reach from the starting position

Solution: keep the jump value the same as it was. Without adjusting it to the frame rate changes described above, it makes the jump height 5 times higher.

To do: I'd recommend to decrease the gopher size. I can't fit >.<